### PR TITLE
Adds proper management subnet injection.

### DIFF
--- a/parts/kuberneteswindowssetup.ps1
+++ b/parts/kuberneteswindowssetup.ps1
@@ -302,6 +302,7 @@ Update-CNIConfig(`$podCIDR, `$masterSubnetGW)
   ""name"": ""<NetworkMode>"",
   ""type"": ""wincni.exe"",
   ""master"": ""Ethernet"",
+  ""capabilities"": { ""portMappings"": true },
   ""ipam"": {
      ""environment"": ""azure"",
      ""subnet"":""<PODCIDR>"",


### PR DESCRIPTION
**What this PR does / why we need it**: This adds an exclusion rule the Windows node in a Kubernetes deployment to exclude the management subnet from NAT'ing.

**Special notes for your reviewer**: I've tested this by doing a fresh build (through docker) and subsequent deployment from this branch and ensuring that `curl`ing the cluster IP works from the Linux master (which was the primary symptom of this issue). Dinesh also has access to this cluster so he can help validate further scenarios.